### PR TITLE
pacstrap: try to copy the host keyring before installing packages

### DIFF
--- a/pacstrap.in
+++ b/pacstrap.in
@@ -92,23 +92,23 @@ fi
 
 # create obligatory directories
 msg 'Creating install root at %s' "$newroot"
-mkdir -m 0755 -p "$newroot"/var/{cache/pacman/pkg,lib/pacman,log} "$newroot"/{dev,run,etc}
+mkdir -m 0755 -p "$newroot"/var/{cache/pacman/pkg,lib/pacman,log} "$newroot"/{dev,run,etc/pacman.d}
 mkdir -m 1777 -p "$newroot"/tmp
 mkdir -m 0555 -p "$newroot"/{sys,proc}
 
 # mount API filesystems
 chroot_setup "$newroot" || die "failed to setup chroot %s" "$newroot"
 
-msg 'Installing packages to %s' "$newroot"
-if ! pacman -r "$newroot" -Sy "${pacman_args[@]}"; then
-  die 'Failed to install packages to new root'
-fi
-
 if (( copykeyring )); then
   # if there's a keyring on the host, copy it into the new root, unless it exists already
   if [[ -d /etc/pacman.d/gnupg && ! -d $newroot/etc/pacman.d/gnupg ]]; then
     cp -a /etc/pacman.d/gnupg "$newroot/etc/pacman.d/"
   fi
+fi
+
+msg 'Installing packages to %s' "$newroot"
+if ! pacman -r "$newroot" -Sy "${pacman_args[@]}"; then
+  die 'Failed to install packages to new root'
 fi
 
 if (( copymirrorlist )); then


### PR DESCRIPTION
When there is no keyring in the new root, attempting to install e.g. archlinux-keyring will result in the post-install script silently failing to do anything (because there are no keys, and, critically, no secret keys). The potentially very outdated keyring is then copied over from the host, secret key and all, so subsequent pacman operations have a trusted keyring that is at least as recent as the ISO or other host system... but if there has been a keyring update between the date of the ISO creation and the date of the install, those keys will continue to be missing until the next keyring update, resulting in a bad out-of-the-box experience.

This also means that if a thirdparty keyring package was scheduled to be installed, it will not be populated at all; this affects downstream archlinux32 build chroots.

There's no reason to delay this until after packages are installed -- we aren't afraid of e.g. the mirrorlist resulting in file conflicts due to a packaged pacman-mirrorlist, because the gnupg configuration should not be getting packaged directly.

Fixes FS#61296 FS#61304 FS#61309 FS#61312 FS#62355