### PR TITLE
Fix a typo in common

### DIFF
--- a/common
+++ b/common
@@ -243,7 +243,6 @@ dm_name_for_devnode() {
   else
     # don't leave the caller hanging, just print the original name
     # along with the failure.
-    print '%s' "$1"
     error 'Failed to resolve device mapper name for: %s' "$1"
   fi
 }


### PR DESCRIPTION
While trying to package this project to nixpkgs, I noticed a possible
typo in common which caused my build to fail, as my build environment
could not figure out a path to the `print` binary.

As there is no `print` binary on my arch installation either (see below), I therefore
suspect the intended call was `printf`, not `print`.

```
[root@yunix /]# which print
which: no print in (/root/.nix-profile/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```