### PR TITLE
Bind mount /run read-only

### DIFF
--- a/common
+++ b/common
@@ -89,7 +89,7 @@ chroot_setup() {
   chroot_add_mount udev "$1/dev" -t devtmpfs -o mode=0755,nosuid &&
   chroot_add_mount devpts "$1/dev/pts" -t devpts -o mode=0620,gid=5,nosuid,noexec &&
   chroot_add_mount shm "$1/dev/shm" -t tmpfs -o mode=1777,nosuid,nodev &&
-  chroot_add_mount /run "$1/run" --bind &&
+  chroot_add_mount /run "$1/run" --bind -r &&
   chroot_add_mount tmp "$1/tmp" -t tmpfs -o mode=1777,strictatime,nodev,nosuid
 }
 


### PR DESCRIPTION
Avoid e.g. systemd-tmpfiles from tampering /run (of the host):

fchownat() of /run/systemd/netif failed: Read-only file system
fchownat() of /run/systemd/netif/links failed: Read-only file system
fchownat() of /run/systemd/netif/leases failed: Read-only file system
fchownat() of /run/systemd/netif/lldp failed: Read-only file system

In this particular case, it could cause unexpected (and unnecessary)
change of ownership to these directories (because of automatic uid/gid
allocation), which could prevent systemd-networkd from working.

Besides, the chroot should under no circumstances (actually) need any
(read-)write access to /run. If there's such need, we should not bind
mount.

Ref.: https://bugs.archlinux.org/task/61808