### PR TITLE
Added argument info to arch-chroot --help

### DIFF
--- a/arch-chroot.in
+++ b/arch-chroot.in
@@ -6,7 +6,7 @@ m4_include(common)
 
 usage() {
   cat <<EOF
-usage: ${0##*/} chroot-dir [command] [arguments]
+usage: ${0##*/} chroot-dir [command] [arguments...]
 
     -h                  Print this help message
     -u <user>[:group]   Specify non-root user and optional group to use

--- a/arch-chroot.in
+++ b/arch-chroot.in
@@ -6,7 +6,7 @@ m4_include(common)
 
 usage() {
   cat <<EOF
-usage: ${0##*/} chroot-dir [command]
+usage: ${0##*/} chroot-dir [command] [arguments]
 
     -h                  Print this help message
     -u <user>[:group]   Specify non-root user and optional group to use

--- a/doc/arch-chroot.8.asciidoc
+++ b/doc/arch-chroot.8.asciidoc
@@ -7,7 +7,7 @@ arch-chroot - enhanced chroot command
 
 Synopsis
 --------
-arch-chroot [options] chroot-dir [command]
+arch-chroot [options] chroot-dir [command] [arguments...]
 
 Description
 -----------


### PR DESCRIPTION
Hi,

I wanted to pass some arguments to arch-chroot's command but assumed that that's impossible due to it being an undocumented feature, so I added documentation so other people don't have to go trough that.

Cheers