### PR TITLE
pacstrap: add an option to initialize an empty keyring in the new root

### DIFF
--- a/completion/pacstrap.bash
+++ b/completion/pacstrap.bash
@@ -8,7 +8,7 @@ _pacstrap() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-C -c -G -i -M -N -h"
+    opts="-C -c -G -i -K -M -N -h"
 
     for i in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
         if [[ -d ${i} ]]; then

--- a/doc/pacstrap.8.asciidoc
+++ b/doc/pacstrap.8.asciidoc
@@ -34,6 +34,9 @@ Options
 *-i*::
 	Prompt for package confirmation when needed (run interactively).
 
+*-K*::
+	Initialize an empty pacman keyring in the target (implies '-G').
+
 *-M*::
 	Avoid copying the host's mirrorlist to the target.
 

--- a/pacstrap.in
+++ b/pacstrap.in
@@ -14,6 +14,7 @@ m4_include(common)
 
 hostcache=0
 copykeyring=1
+initkeyring=0
 copymirrorlist=1
 pacmode=-Sy
 setup=chroot_setup
@@ -28,6 +29,7 @@ usage: ${0##*/} [options] root [packages...]
     -c             Use the package cache on the host, rather than the target
     -G             Avoid copying the host's pacman keyring to the target
     -i             Prompt for package confirmation when needed (run interactively)
+    -K             Initialize an empty pacman keyring in the target (implies '-G')
     -M             Avoid copying the host's mirrorlist to the target
     -N             Run in unshare mode as a regular user
     -U             Use pacman -U to install packages
@@ -45,7 +47,7 @@ if [[ -z $1 || $1 = @(-h|--help) ]]; then
   exit $(( $# ? 0 : 1 ))
 fi
 
-while getopts ':C:cdGiMNU' flag; do
+while getopts ':C:cdGiKMNU' flag; do
   case $flag in
     C)
       pacman_config=$OPTARG
@@ -61,6 +63,9 @@ while getopts ':C:cdGiMNU' flag; do
       ;;
     G)
       copykeyring=0
+      ;;
+    K)
+      initkeyring=1
       ;;
     M)
       copymirrorlist=0
@@ -112,9 +117,11 @@ pacstrap() {
   # mount API filesystems
   $setup "$newroot" || die "failed to setup chroot %s" "$newroot"
 
-  if (( copykeyring )); then
-    # if there's a keyring on the host, copy it into the new root, unless it exists already
-    if [[ -d /etc/pacman.d/gnupg && ! -d $newroot/etc/pacman.d/gnupg ]]; then
+  if [[ ! -d $newroot/etc/pacman.d/gnupg ]]; then
+    if (( initkeyring )); then
+      pacman-key --gpgdir "$newroot"/etc/pacman.d/gnupg --init
+    elif (( copykeyring )) && [[ -d /etc/pacman.d/gnupg ]]; then
+      # if there's a keyring on the host, copy it into the new root
       cp -a --no-preserve=ownership /etc/pacman.d/gnupg "$newroot/etc/pacman.d/"
     fi
   fi


### PR DESCRIPTION
As I explained in [archiso#190](https://gitlab.archlinux.org/archlinux/archiso/-/issues/190), the keyring on the host might have been initialized before the correct system time is set, resulting in future issues. As [FS#62826](https://bugs.archlinux.org/task/62826) has been fixed, `archlinux-keyring` can now populate itself during installation. So, when `-G` is specified, instead of doing nothing, we can initialize an empty keyring and let pacman do the populating.

Also, I'm hoping that we can make this default in the future, which would fix the archiso issue without "automating and pre-configuring even more things" on their side :)