### PR TITLE
add blkid method for uuid

### DIFF
--- a/genfstab.in
+++ b/genfstab.in
@@ -9,6 +9,10 @@ write_source() {
 
   label=$(lsblk -rno LABEL "$1" 2>/dev/null)
   uuid=$(lsblk -rno UUID "$1" 2>/dev/null)
+  if [ -z $uuid ]; then
+    uuid=$(blkid "$1" -o export | grep -i "^UUID" | cut -c 6- 2>/dev/null)
+  fi
+
 
   # bind mounts do not have a UUID!
 

--- a/genfstab.in
+++ b/genfstab.in
@@ -9,8 +9,8 @@ write_source() {
 
   label=$(lsblk -rno LABEL "$1" 2>/dev/null)
   uuid=$(lsblk -rno UUID "$1" 2>/dev/null)
-  if [ -z $uuid ]; then
-    uuid=$(blkid "$1" -o export | grep -i "^UUID" | cut -c 6- 2>/dev/null)
+  if [[ -z $uuid ]]; then
+    uuid=$(blkid -s UUID -o value "$1" 2>/dev/null)
   fi
 
 


### PR DESCRIPTION
Hello, using this script, we periodically encountered the problem that "uuid" was not defined on some sections. In the process of studying the problem, it became clear that partition have uuid, but lsblk cannot determine it and gives an empty string. At the same time, BLKID handles uuid detection, I suggest adding BLKID as a fallback way to get uuid to minimize situations when uuid is present but cannot be detected.