### PR TITLE
genfstab: fix src of bind mounts

### DIFF
--- a/genfstab.in
+++ b/genfstab.in
@@ -166,6 +166,7 @@ findmnt -Recvruno SOURCE,TARGET,FSTYPE,OPTIONS,FSROOT "$root" |
   if [[ $fsroot != / && $fstype != btrfs ]]; then
     # it's a bind mount
     src=$(findmnt -funcevo TARGET "$src")$fsroot
+    src="/${src#$root/}"
     if [[ $src -ef $target ]]; then
       # hrmm, this is weird. we're probably looking at a file or directory
       # that was bound into a chroot from the host machine. Ignore it,


### PR DESCRIPTION
Sources of bind mounts in fstab should be relative to the target's root instead of the host one. And the check logic below (`[[ $src -ef $target ]]`) only works in this way, too.

Let's take the bind mount method of mounting the ESP (described in [ArchWiki](https://wiki.archlinux.org/title/EFI_system_partition#Using_bind_mount)) as an example. After running `mount --bind /mnt/efi/EFI/arch /mnt/boot` in the installation medium, `genfstab` would generate an entry like this:

`/mnt/efi/EFI/arch          	/boot     	none      	sth,bind	0 0`

which won't work after booting into the installed system.