### PR TITLE
common: disable btrfs fsck in fsck_types

### DIFF
--- a/common
+++ b/common
@@ -56,7 +56,7 @@ declare -A pseudofs_types=([anon_inodefs]=1
                            [virtiofs]=1)
 
 # generated from: pkgfile -vbr '/fsck\..+' | awk -F. '{ print $NF }' | sort
-declare -A fsck_types=([btrfs]=1
+declare -A fsck_types=([btrfs]=0    # btrfs doesn't need a regular fsck utility
                        [cramfs]=1
                        [erofs]=1
                        [exfat]=1


### PR DESCRIPTION
Btrfs doesn't need nor use a regular fsck utility. This was wrongly added in b31a5d9f94e9293f47ac42455094767459b17c20 and currently makes `genfstab` generate btrfs entries with `fs_passno` not set to `0`, which was set in previous releases.

I'd like to keep the entry in `fsck_types` and explicitly set it to 0 for future-proof reasons.