### PR TITLE
pacstrap: remove obsolete option '-d' completely

### DIFF
--- a/pacstrap.in
+++ b/pacstrap.in
@@ -47,13 +47,10 @@ if [[ -z $1 || $1 = @(-h|--help) ]]; then
   exit $(( $# ? 0 : 1 ))
 fi
 
-while getopts ':C:cdGiKMNU' flag; do
+while getopts ':C:cGiKMNU' flag; do
   case $flag in
     C)
       pacman_config=$OPTARG
-      ;;
-    d)
-      # retired flag. does nothing.
       ;;
     c)
       hostcache=1


### PR DESCRIPTION
This has been obsolete for 4 years and I can hardly imagine people still using it (only to find that it doesn't actually work).