### PR TITLE
arch-chroot: add option to preserve the chroot resolv.conf

### DIFF
--- a/arch-chroot.in
+++ b/arch-chroot.in
@@ -3,6 +3,7 @@
 shopt -s extglob
 
 unshare=0
+keepresolvconf=0
 
 m4_include(common)
 
@@ -13,6 +14,7 @@ usage: ${0##*/} chroot-dir [command] [arguments...]
     -h                  Print this help message
     -N                  Run in unshare mode as a regular user
     -u <user>[:group]   Specify non-root user and optional group to use
+    -r                  Do not change the resolv.conf within the chroot
 
 If 'command' is unspecified, ${0##*/} will launch /bin/bash.
 
@@ -79,7 +81,9 @@ arch-chroot() {
   [[ -d $chrootdir ]] || die "Can't create chroot on non-directory %s" "$chrootdir"
 
   $setup "$chrootdir" || die "failed to setup chroot %s" "$chrootdir"
-  chroot_add_resolv_conf "$chrootdir" || die "failed to setup resolv.conf"
+  if (( ! keepresolvconf )); then
+    chroot_add_resolv_conf "$chrootdir" || die "failed to setup resolv.conf"
+  fi
 
   if ! mountpoint -q "$chrootdir"; then
     warning "$chrootdir is not a mountpoint. This may have undesirable side effects."
@@ -91,7 +95,7 @@ arch-chroot() {
   SHELL=/bin/bash $pid_unshare chroot "${chroot_args[@]}" -- "$chrootdir" "${args[@]}"
 }
 
-while getopts ':hNu:' flag; do
+while getopts ':hNu:r' flag; do
   case $flag in
     h)
       usage
@@ -102,6 +106,9 @@ while getopts ':hNu:' flag; do
       ;;
     u)
       userspec=$OPTARG
+      ;;
+    r)
+      keepresolvconf=1
       ;;
     :)
       die '%s: option requires an argument -- '\''%s'\' "${0##*/}" "$OPTARG"

--- a/completion/bash/arch-chroot
+++ b/completion/bash/arch-chroot
@@ -2,7 +2,7 @@ _arch_chroot() {
     compopt +o dirnames
     local cur prev opts i
     _init_completion -n : || return
-    opts="-N -u -h"
+    opts="-N -u -r -h"
 
     for i in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
         if [[ -d ${i} ]]; then

--- a/completion/zsh/_arch-chroot
+++ b/completion/zsh/_arch-chroot
@@ -5,6 +5,7 @@ local -a args=(
     '(-h --help)'{-h,--help}'[display help]'
     '-N[Run in unshare mode as a regular user]'
     '-u[The non-root user and optional group to use]: :->userspecs'
+    '-r[Do not change the resolv.conf within the chroot]'
     '1:new root directory:_directories'
     '*:::command:_normal'
 )

--- a/doc/arch-chroot.8.asciidoc
+++ b/doc/arch-chroot.8.asciidoc
@@ -40,6 +40,10 @@ Options
 *-u <user>[:group]*::
 	Specify non-root user and optional group to use.
 
+*-r*::
+	Do not change the resolv.conf within the chroot. This means that the resolver
+	might not work in the chroot, which could be the required state.
+
 *-h*::
 	Output syntax and command line options.
 


### PR DESCRIPTION
There is a comprehensive inline comment about why we're touching the
chroot resolv.conf. Although it does not consider the cases where:
 - the link may be broken for specific reasons, and/or
 - working resolver within the chroot is not wanted
 
Note: there is a set of minor conflicts with a few other MR https://github.com/archlinux/arch-install-scripts/pull/48 and https://github.com/archlinux/arch-install-scripts/pull/49, so I've decided to include them here as a base. Happy to reshuffle the lot.