### PR TITLE
common: ensure /run is mounted with --make-private

### DIFF
--- a/common
+++ b/common
@@ -115,7 +115,7 @@ chroot_setup() {
   chroot_add_mount udev "$1/dev" -t devtmpfs -o mode=0755,nosuid &&
   chroot_add_mount devpts "$1/dev/pts" -t devpts -o mode=0620,gid=5,nosuid,noexec &&
   chroot_add_mount shm "$1/dev/shm" -t tmpfs -o mode=1777,nosuid,nodev &&
-  chroot_add_mount run "$1/run" -t tmpfs -o nosuid,nodev,mode=0755 &&
+  chroot_add_mount /run "$1/run" --bind --make-private &&
   chroot_add_mount tmp "$1/tmp" -t tmpfs -o mode=1777,strictatime,nodev,nosuid
 }
 


### PR DESCRIPTION
udev doesn't work in the chroot which prevents some tools like lsblk to retrieve the UUID of devices. This can be a bit problematic so instead of having /run mounted as a tmpfs, do a bind-mound from the rootfs and include `--make-private`.

This is similar to the previous implemention.

Fixes https://github.com/archlinux/arch-install-scripts/issues/24