### PR TITLE
arch-chroot: bind mount over a /etc/resolv.conf symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ tasks when installing [Arch Linux](https://www.archlinux.org).
 ## Requirements
 
 * GNU coreutils (>= v8.15)
-* util-linux (>= 2.23)
+* util-linux (>= 2.39)
 * POSIX awk
 * bash (>= 4.1)
 * asciidoc (for generating man pages)

--- a/arch-chroot.in
+++ b/arch-chroot.in
@@ -48,34 +48,20 @@ resolve_link() {
 chroot_add_resolv_conf() {
   local chrootdir=$1
   local src
-  local dest
+  local dest="$chrootdir/etc/resolv.conf"
 
   src=$(resolve_link /etc/resolv.conf)
-  dest=$(resolve_link "$chrootdir/etc/resolv.conf" "$chrootdir")
 
   # If we don't have a source resolv.conf file, there's nothing useful we can do.
   [[ -e $src ]] || return 0
 
-  if [[ ! -e $dest ]]; then
-    # There are two reasons the destination might not exist:
-    #
-    #   1. There may be no resolv.conf in the chroot.  In this case, $dest won't exist,
-    #      and it will be equal to $1/etc/resolv.conf.  In this case, we'll just exit.
-    #      The chroot environment must not be concerned with DNS resolution.
-    #
-    #   2. $1/etc/resolv.conf is (or resolves to) a broken link.  The environment
-    #      clearly intends to handle DNS resolution, but something's wrong.  Maybe it
-    #      normally creates the target at boot time.  We'll (try to) take care of it by
-    #      creating a dummy file at the target, so that we have something to bind to.
-
-    # Case 1.
-    [[ $dest = $chrootdir/etc/resolv.conf ]] && return 0
-
-    # Case 2.
-    install -Dm644 /dev/null "$dest" || return 1
+  if [[ ! -e "$dest" && ! -h "$dest" ]]; then
+    # There may be no resolv.conf in the chroot. In this case, we'll just exit.
+    # The chroot environment must not be concerned with DNS resolution.
+    return 0
   fi
 
-  chroot_add_mount "$src" "$dest" --bind
+  chroot_add_mount "$src" "$dest" -c --bind
 }
 
 arch-chroot() {


### PR DESCRIPTION
Use `mount`'s a `-c`/`--no-canonicalize` option to ensure the bind mount to `/etc/resolv.conf` in the chroot directory is mounted correctly. This avoids issues when the chroot's `/etc/resolv.conf` is a symlink.

Fixes https://github.com/archlinux/arch-install-scripts/issues/55
Related to https://github.com/util-linux/util-linux/issues/2370
