### PR TITLE
Fix unshare chroot symlinks

### DIFF
--- a/common
+++ b/common
@@ -67,10 +67,10 @@ unshare_setup() {
   chroot_add_mount_lazy "$1" "$1" --bind &&
   chroot_add_mount proc "$1/proc" -t proc -o nosuid,noexec,nodev &&
   chroot_add_mount_lazy /sys "$1/sys" --rbind &&
-  chroot_add_link "$1/proc/self/fd" "$1/dev/fd" &&
-  chroot_add_link "$1/proc/self/fd/0" "$1/dev/stdin" &&
-  chroot_add_link "$1/proc/self/fd/1" "$1/dev/stdout" &&
-  chroot_add_link "$1/proc/self/fd/2" "$1/dev/stderr" &&
+  chroot_add_link /proc/self/fd "$1/dev/fd" &&
+  chroot_add_link /proc/self/fd/0 "$1/dev/stdin" &&
+  chroot_add_link /proc/self/fd/1 "$1/dev/stdout" &&
+  chroot_add_link /proc/self/fd/2 "$1/dev/stderr" &&
   chroot_bind_device /dev/full "$1/dev/full" &&
   chroot_bind_device /dev/null "$1/dev/null" &&
   chroot_bind_device /dev/random "$1/dev/random" &&


### PR DESCRIPTION
When I run `arch-chroot` in unshare mode, it creates invalid symlinks for `fd`, `stderr`, `stdin`, and `stdout` devices:
![image](https://github.com/archlinux/arch-install-scripts/assets/8599643/902f5b81-a72c-4db2-9bee-281b5f74cd90)

This PR fixes these symlink paths:
![image](https://github.com/archlinux/arch-install-scripts/assets/8599643/747da39d-9524-4231-8e3b-c3a4ce08eec7)
